### PR TITLE
fix:User PK 명명 일치

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,9 +43,6 @@ src/main/resources/application-secrets.yml
 ### Docker & Database ###
 postgres_data/
 
-### QueryDSL ###
-src/main/generated/
-
 ### Claude Code ###
 CLAUDE.md
 .claude/

--- a/build.gradle
+++ b/build.gradle
@@ -57,16 +57,12 @@ tasks.named('test') {
 	useJUnitPlatform()
 }
 
-def querydslDir = "src/main/generated"
+def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
 
 tasks.withType(JavaCompile).configureEach {
-	options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+	options.getGeneratedSourceOutputDirectory().set(querydslDir)
 }
 
 sourceSets {
 	main.java.srcDirs += [ querydslDir ]
-}
-
-clean {
-	delete file(querydslDir)
 }

--- a/src/main/java/bluepill/server/repository/CharacterCardRepositoryImpl.java
+++ b/src/main/java/bluepill/server/repository/CharacterCardRepositoryImpl.java
@@ -115,7 +115,7 @@ public class CharacterCardRepositoryImpl implements CharacterCardRepositoryCusto
                         c.updatedAt))
                 .from(c)
                 .where(
-                        c.creator.id.eq(creatorId),
+                        c.creator.userId.eq(creatorId),
                         c.isDeleted.isFalse(),
                         publicOnlyCondition(c, includePrivate),
                         cursorConditionLatest(c, cursor)

--- a/src/main/java/bluepill/server/service/CharacterCardService.java
+++ b/src/main/java/bluepill/server/service/CharacterCardService.java
@@ -87,7 +87,7 @@ public class CharacterCardService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.CHARACTER_CARD_NOT_FOUND));
 
         boolean isOwner = (viewerId != null)
-                && card.getCreator().getId().equals(viewerId);
+                && card.getCreator().getUserId().equals(viewerId);
 
         // 비공개 카드인데 본인 아님 → 403
         if (!card.getIsPublic() && !isOwner) {
@@ -108,11 +108,11 @@ public class CharacterCardService {
             UUID targetUserPublicId, Long viewerId, UUID cursor, int size) {
 
         User target = userService.findByPublicId(targetUserPublicId); //없거나 탈퇴면 USER_NOT_FOUND
-        boolean isOwner = (viewerId != null) && target.getId().equals(viewerId);
+        boolean isOwner = (viewerId != null) && target.getUserId().equals(viewerId);
 
         // 본인이면 비공개도 포함
         List<UserCharacterCardListItem> result = characterCardRepository.findByCreator(
-                target.getId(), isOwner, cursor, size);
+                target.getUserId(), isOwner, cursor, size);
 
         boolean hasNext = result.size() > size;
         if (hasNext) {


### PR DESCRIPTION
## #️⃣연관된 이슈


## 📝작업 내용

- User PK 명명을 userId로 일치시킴. 
- querydsl 생성 위치를 build/generated/ 로 이동

## 💬리뷰 요구사항(선택)