### PR TITLE
feat: 로그아웃 기능 추가 

### DIFF
--- a/src/main/java/bluepill/server/config/SecurityConfig.java
+++ b/src/main/java/bluepill/server/config/SecurityConfig.java
@@ -32,7 +32,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
-                                "/auth/reissue").permitAll()
+                                "/auth/reissue",
+                                "/auth/logout").permitAll()
 
                         //그 외에는 요청 인증 필요
                         .anyRequest().authenticated()

--- a/src/main/java/bluepill/server/controller/AuthController.java
+++ b/src/main/java/bluepill/server/controller/AuthController.java
@@ -7,7 +7,11 @@ import bluepill.server.service.AuthService;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,6 +24,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
     private final AuthService authService;
 
+    @Value("${app.cookie.secure}")
+    private boolean secure;
+
+    @Value("${app.cookie.same-site}")
+    private String sameSite;
+
     @PostMapping("/reissue")
     public ApiResponse<TokenResponse> reissue(@Parameter(
             name = "refreshToken",
@@ -29,5 +39,21 @@ public class AuthController {
     )@CookieValue(value = "refreshToken") String refreshToken) {
         TokenResponse response = authService.reissue(refreshToken);
         return ApiResponse.success("토큰이 재발급 되었습니다", response);
+    }
+
+    @PostMapping("/logout")
+    public ApiResponse<Void> logout(@CookieValue(value = "refreshToken") String refreshToken, HttpServletResponse response) {
+        authService.logout(refreshToken);
+
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                .secure(secure) //운영에서 true
+                .path("/")
+                .maxAge(0)
+                .sameSite(sameSite)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        return ApiResponse.success("로그아웃 되었습니다.", null);
     }
 }

--- a/src/main/java/bluepill/server/domain/UserToken.java
+++ b/src/main/java/bluepill/server/domain/UserToken.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class UserToken {
+public class UserToken extends BaseTimeEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,33 +24,26 @@ public class UserToken {
     private Long tokenId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false, unique=true)
     private User user;
 
     @Column(name = "refresh_token", nullable = false)
     private String refreshToken;
 
-    @CreationTimestamp
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
 
-    @Column(name = "expired_at", nullable = false)
-    private LocalDateTime expiredAt;
-
-    @UpdateTimestamp
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
     // 토큰 생성
-    public static UserToken createToken(User user, String refreshToken) {
+    public static UserToken createToken(User user, String refreshToken, LocalDateTime expiresAt) {
         return UserToken.builder()
                 .user(user)
                 .refreshToken(refreshToken)
-                .expiredAt(LocalDateTime.now().plusDays(7))
+                .expiresAt(expiresAt)
                 .build();
     }
 
-    public void updateRefreshToken(String refreshToken, LocalDateTime expiredAt) {
+    public void updateRefreshToken(String refreshToken, LocalDateTime expiresAt) {
         this.refreshToken = refreshToken;
-        this.expiredAt = LocalDateTime.now().plusDays(7);
+        this.expiresAt = expiresAt;
     }
 }

--- a/src/main/java/bluepill/server/jwt/JwtConfig.java
+++ b/src/main/java/bluepill/server/jwt/JwtConfig.java
@@ -1,4 +1,4 @@
-package bluepill.server.config;
+package bluepill.server.jwt;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -10,7 +10,6 @@ import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
 import com.nimbusds.jose.jwk.source.ImmutableSecret;
 
-import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;

--- a/src/main/java/bluepill/server/jwt/JwtProvider.java
+++ b/src/main/java/bluepill/server/jwt/JwtProvider.java
@@ -1,6 +1,5 @@
 package bluepill.server.jwt;
 
-import bluepill.server.config.JwtConfig;
 import bluepill.server.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;

--- a/src/main/java/bluepill/server/service/AuthService.java
+++ b/src/main/java/bluepill/server/service/AuthService.java
@@ -6,6 +6,7 @@ import bluepill.server.dto.user.TokenResponse;
 import bluepill.server.exception.BusinessException;
 import bluepill.server.exception.ErrorCode;
 import bluepill.server.jwt.JwtProvider;
+import bluepill.server.repository.UserRepository;
 import bluepill.server.repository.UserTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +18,7 @@ public class AuthService {
 
     private final JwtProvider jwtProvider;
     private final UserTokenRepository userTokenRepository;
+    private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
     public TokenResponse reissue(String refreshToken) {
@@ -33,5 +35,11 @@ public class AuthService {
         boolean isNewUser = user.getNickname() == null;
 
         return new TokenResponse(accessToken, isNewUser);
+    }
+
+    public void logout(String refreshToken) {
+        if(refreshToken == null || refreshToken.isBlank()) return;
+
+        userTokenRepository.findByRefreshToken(refreshToken).ifPresent(userTokenRepository :: delete);
     }
 }

--- a/src/main/java/bluepill/server/service/OAuth2SuccessHandler.java
+++ b/src/main/java/bluepill/server/service/OAuth2SuccessHandler.java
@@ -1,10 +1,10 @@
 package bluepill.server.service;
 
-import bluepill.server.config.JwtConfig;
 import bluepill.server.domain.User;
 import bluepill.server.domain.UserToken;
 import bluepill.server.exception.BusinessException;
 import bluepill.server.exception.ErrorCode;
+import bluepill.server.jwt.JwtConfig;
 import bluepill.server.jwt.JwtProvider;
 import bluepill.server.repository.UserRepository;
 import bluepill.server.repository.UserTokenRepository;
@@ -45,21 +45,21 @@ public class OAuth2SuccessHandler  extends SimpleUrlAuthenticationSuccessHandler
         // JWT 발급
         String refreshToken = jwtProvider.generateRefreshToken(user);
 
-        LocalDateTime expiredAt = LocalDateTime.now()
+        LocalDateTime expiresAt = LocalDateTime.now()
                 .plusSeconds(jwtConfig.getRefreshTokenExpiration());
 
-        // 최초로그인 시 refreshToken생성, 만료 후 로그인일 경우 token값+만료일 update
+        // refreshToken생성, 만료 후 로그인일 경우 token값+만료일 update
         UserToken userToken  = userTokenRepository.findByUser(user)
                 .map(token -> {
-                    token.updateRefreshToken(refreshToken, expiredAt);
+                    token.updateRefreshToken(refreshToken, expiresAt);
                     return token;
                 })
-                .orElseGet(() -> UserToken.createToken(user, refreshToken));
+                .orElseGet(() -> UserToken.createToken(user, refreshToken, expiresAt));
         userTokenRepository.save(userToken);
 
         response.addCookie(createRefreshTokenCookie(refreshToken));
 
-        String redirectUrl = "http://localhost:3000/callback";
+        String redirectUrl = "http://localhost:5173/auth/callback";
         getRedirectStrategy().sendRedirect(request, response, redirectUrl);
     }
 
@@ -68,7 +68,7 @@ public class OAuth2SuccessHandler  extends SimpleUrlAuthenticationSuccessHandler
         cookie.setHttpOnly(true);
         cookie.setSecure(false); // 로컬 개발에서는 false
         cookie.setPath("/");
-        cookie.setMaxAge(60 * 60 * 24 * 7);
+        cookie.setMaxAge((int)jwtConfig.getRefreshTokenExpiration());
         return cookie;
     }
 

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -12,3 +12,10 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
+
+app:
+  frontend:
+    oauth-callback-url: http://localhost:5173/auth/callback
+  cookie:
+    secure: false
+    same-site: Lax

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -18,3 +18,12 @@ spring:
 springdoc:
   swagger-ui:
     enabled: false
+  api-docs:
+    enabled: false
+
+app:
+  frontend:
+    oauth-callback-url: ${FRONTEND_OAUTH_CALLBACK_URL}
+  cookie:
+    secure: true
+    same-site: ${COOKIE_SAME_SITE:None}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,6 +10,17 @@ spring:
     import:
       - optional:application-secrets.yml
 
+jwt:
+  access-token-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION:3600}
+  refresh-token-expiration: ${JWT_REFRESH_TOKEN_EXPIRATION:604800}
+
+app:
+  frontend:
+    oauth-callback-url: ${FRONTEND_OAUTH_CALLBACK_URL:http://localhost:5173/auth/callback}
+  cookie:
+    secure: ${COOKIE_SECURE:false}
+    same-site: ${COOKIE_SAME_SITE:Lax}
+
 springdoc:
   swagger-ui:
     path: /swagger-ui.html


### PR DESCRIPTION
## #️⃣연관된 이슈
#24 

> 예시
>
> - 기능 추가: fixes #이슈번호
> - 버그 수정: fixes #이슈번호
> - 프론트엔드/백엔드 레포가 분리된 경우: 기능 추가시, fixes enb-solution/레포지토리명#이슈번호
    >   버그 수정시, fixes enb-solution/레포지토리명#이슈번호
    >   ⚠️ 다른 레포 이슈는 자동 close 되지 않으며, 링크만 연결됩니다.

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 로그아웃 시 token row 삭제처리
- 재로그인 시 새 token row 추가
- 
## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

revoked_at 컬럼을 삭제하고, 로그아웃 시 token 데이터를 삭제하는 플로우로 처리했습니다.
- 사용자가 로그아웃 했을 경우: refreshToken 데이터 삭제
- RefreshToken이 만료됐을 경우: 재 로그인을 통해 refreshToken row의 만료시간과 token 값 업데이트