### PR TITLE
feat: 테스트용 accessToken 생성 기능 추가

### DIFF
--- a/src/main/java/bluepill/server/config/SecurityConfig.java
+++ b/src/main/java/bluepill/server/config/SecurityConfig.java
@@ -33,7 +33,9 @@ public class SecurityConfig {
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/auth/reissue",
-                                "/auth/logout").permitAll()
+                                "/auth/logout",
+                                "/dev/token/**"
+                                ).permitAll()
 
                         //그 외에는 요청 인증 필요
                         .anyRequest().authenticated()

--- a/src/main/java/bluepill/server/config/SwaggerConfig.java
+++ b/src/main/java/bluepill/server/config/SwaggerConfig.java
@@ -1,19 +1,32 @@
 package bluepill.server.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
 
+    private static final String SECURITY_SCHEME_NAME = "Bearer Authentication";
+
     @Bean
     public OpenAPI openAPI(){
         return new OpenAPI()
                 .info(new Info()
-                        .title("Server API")
-                        .description("API 테스트 문서")
-                        .version("v1.0.0"));
+                        .title("Bluepill API")
+                        .description("Bluepill API 테스트 문서")
+                        .version("v1.0.0"))
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+                .components(new Components()
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME,
+                                new SecurityScheme()
+                                        .name(SECURITY_SCHEME_NAME)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")));
     }
 }

--- a/src/main/java/bluepill/server/controller/DevAuthController.java
+++ b/src/main/java/bluepill/server/controller/DevAuthController.java
@@ -1,0 +1,44 @@
+package bluepill.server.controller;
+
+import bluepill.server.domain.User;
+import bluepill.server.dto.common.ApiResponse;
+import bluepill.server.dto.user.TokenResponse;
+import bluepill.server.exception.BusinessException;
+import bluepill.server.exception.ErrorCode;
+import bluepill.server.jwt.JwtProvider;
+import bluepill.server.repository.UserRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name="DevAuth")
+@Profile({"local"})
+@RestController
+@RequestMapping("/dev/token")
+@RequiredArgsConstructor
+public class DevAuthController {
+
+    private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+
+    @Operation(
+            summary = "테스트용 accessToken 발급",
+            description = "개발/테스트 환경에서 userId로 accessToken을 발급합니다. 운영 환경에서는 비활성화됩니다."
+    )
+    @PostMapping
+    public ApiResponse<TokenResponse> issueAccessToken(
+            @Parameter(description = "토큰을 발급할 userId", example = "1")
+            @RequestParam(defaultValue = "1") Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        String accessToken = jwtProvider.generateAccessToken(user);
+
+        return ApiResponse.success(
+                "테스트용 accessToken이 발급되었습니다.",
+                new TokenResponse(accessToken, user.getNickname() == null)
+        );
+    }
+}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -13,6 +13,9 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
+jwt:
+  access-token-expiration: 86400
+
 app:
   frontend:
     oauth-callback-url: http://localhost:5173/auth/callback


### PR DESCRIPTION
## #️⃣연관된 이슈
#28 

> 예시
>
> - 기능 추가: fixes #이슈번호
> - 버그 수정: fixes #이슈번호
> - 프론트엔드/백엔드 레포가 분리된 경우: 기능 추가시, fixes enb-solution/레포지토리명#이슈번호
    >   버그 수정시, fixes enb-solution/레포지토리명#이슈번호
    >   ⚠️ 다른 레포 이슈는 자동 close 되지 않으며, 링크만 연결됩니다.

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- userId를 받아 accessToken 생성
- 로컬에서는 만료시간을 24시간으로 설정
- Swagger에 Authorize 기능 추가

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?