### PR TITLE
feat: 사용자 프로필 조회 기능 추가

### DIFF
--- a/src/main/java/bluepill/server/annotation/CurrentUserId.java
+++ b/src/main/java/bluepill/server/annotation/CurrentUserId.java
@@ -1,0 +1,8 @@
+package bluepill.server.annotation;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUserId {
+}

--- a/src/main/java/bluepill/server/config/CurrentUserIdArgumentResolver.java
+++ b/src/main/java/bluepill/server/config/CurrentUserIdArgumentResolver.java
@@ -1,0 +1,39 @@
+package bluepill.server.config;
+
+import bluepill.server.annotation.CurrentUserId;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class CurrentUserIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUserId.class)
+                && Long.class.isAssignableFrom(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if(authentication == null || !authentication.isAuthenticated()) return null;
+
+        Object principal = authentication.getPrincipal();
+
+        if(principal instanceof Long userId) return userId;
+
+        return null;
+    }
+}

--- a/src/main/java/bluepill/server/config/WebMvcConfig.java
+++ b/src/main/java/bluepill/server/config/WebMvcConfig.java
@@ -1,0 +1,20 @@
+package bluepill.server.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final CurrentUserIdArgumentResolver currentUserIdArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserIdArgumentResolver);
+    }
+}

--- a/src/main/java/bluepill/server/controller/UserController.java
+++ b/src/main/java/bluepill/server/controller/UserController.java
@@ -1,0 +1,34 @@
+package bluepill.server.controller;
+
+import bluepill.server.annotation.CurrentUserId;
+import bluepill.server.dto.common.ApiResponse;
+import bluepill.server.dto.user.UserProfileResponse;
+import bluepill.server.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+@Tag(name="User")
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "프로필 조회", description = "publicId로 사용자의 프로필 정보를 조회합니다. 로그인한 사용자가 본인의 프로필을 조회한 경우 isOwner가 true로 반환됩니다.")
+    @GetMapping("/{publicId}")
+    public ApiResponse<UserProfileResponse> getUserProfile(@Parameter(description = "조회할 사용자의 publicId", example="550e8400-e29b-41d4-a716-446655440000")
+                                                           @PathVariable UUID publicId,
+                                                           @Parameter(hidden = true) @CurrentUserId Long loginUserId){
+        UserProfileResponse response = userService.getProfile(publicId, loginUserId);
+
+        return ApiResponse.success("프로필 조회 성공", response);
+    }
+}

--- a/src/main/java/bluepill/server/domain/User.java
+++ b/src/main/java/bluepill/server/domain/User.java
@@ -36,9 +36,6 @@ public class User extends BaseTimeEntity {
     @Column(name = "provider", nullable = false, length = 20)
     private Provider provider;
 
-    @Column(name = "account_name", length = 20)
-    private String accountName;
-
     @Column(name = "nickname", length = 15)
     private String nickname;
 

--- a/src/main/java/bluepill/server/dto/user/UserProfileResponse.java
+++ b/src/main/java/bluepill/server/dto/user/UserProfileResponse.java
@@ -1,0 +1,17 @@
+package bluepill.server.dto.user;
+
+import java.util.UUID;
+
+public record UserProfileResponse(
+        UUID publicId,
+        String nickname,
+        String profileImageUrl,
+        String email,
+        Long planId,
+        Boolean isPublic,
+        Long characterCnt,
+        Long postCnt,
+        boolean isOwner
+
+) {
+}

--- a/src/main/java/bluepill/server/service/UserService.java
+++ b/src/main/java/bluepill/server/service/UserService.java
@@ -1,6 +1,7 @@
 package bluepill.server.service;
 
 import bluepill.server.domain.User;
+import bluepill.server.dto.user.UserProfileResponse;
 import bluepill.server.exception.BusinessException;
 import bluepill.server.exception.ErrorCode;
 import bluepill.server.repository.UserRepository;
@@ -26,4 +27,27 @@ public class UserService {
         return userRepository.findByPublicIdAndIsDeletedFalse(publicId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
+
+    public UserProfileResponse getProfile(UUID publicId, Long loginUserId) {
+        User user = userRepository.findByPublicIdAndIsDeletedFalse(publicId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        boolean isOwner = loginUserId != null && loginUserId.equals(user.getUserId());
+
+        //todo: 캐릭터, 게시물 개수
+        long characterCnt = 0L;
+        long postCnt = 0L;
+
+        return new UserProfileResponse(
+                user.getPublicId(),
+                user.getNickname(),
+                user.getImageUrl(),
+                user.getEmail(),
+                user.getPlan() != null ? user.getPlan().getId() : null,
+                user.getIsPublic(),
+                characterCnt,
+                postCnt,
+                isOwner
+        );
+    };
 }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -12,36 +12,6 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
-  security:
-    oauth2:
-      client:
-        registration:
-          google:
-            client-id: ${GOOGLE_CLIENT_ID:local-google-client-id}
-            client-secret: ${GOOGLE_CLIENT_SECRET:local-google-client-secret}
-            scope:
-              - email
-              - profile
-          discord:
-            client-id: ${DISCORD_CLIENT_ID:local-discord-client-id}
-            client-secret: ${DISCORD_CLIENT_SECRET:local-discord-client-secret}
-            authorization-grant-type: authorization_code
-            redirect-uri: "{baseUrl}/login/oauth2/code/discord"
-            scope:
-              - identify
-              - email
-        provider:
-          discord:
-            authorization-uri: https://discord.com/api/oauth2/authorize
-            token-uri: https://discord.com/api/oauth2/token
-            user-info-uri: https://discord.com/api/users/@me
-            user-name-attribute: id
-
-jwt:
-  secret: ${JWT_SECRET:local-jwt-secret-key-should-be-at-least-32-bytes}
-  access-token-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION:3600}
-  refresh-token-expiration: ${JWT_REFRESH_TOKEN_EXPIRATION:604800}
-
 jwt:
   access-token-expiration: 86400
 


### PR DESCRIPTION

## #️⃣연관된 이슈
#32 

> 예시
>
> - 기능 추가: fixes #이슈번호
> - 버그 수정: fixes #이슈번호
> - 프론트엔드/백엔드 레포가 분리된 경우: 기능 추가시, fixes enb-solution/레포지토리명#이슈번호
    >   버그 수정시, fixes enb-solution/레포지토리명#이슈번호
    >   ⚠️ 다른 레포 이슈는 자동 close 되지 않으며, 링크만 연결됩니다.

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 로그인한 사용자가 본인의 프로필을 조회하는지 확인 위해 로그인 사용자 정보 필요
- 매번 로그인한 사용자 정보 확인을 위해 @CurrentUserId resolver설정
- 본인인 경우 isOwner = true 반환
- local과 secret 충돌로 인해 security 설정 삭제

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?