### PR TITLE
feat: 내 프로필 수정, 내 프로필 조회 시 생성한 캐릭터 수 함께 조회

### DIFF
--- a/src/main/java/bluepill/server/controller/UserController.java
+++ b/src/main/java/bluepill/server/controller/UserController.java
@@ -2,16 +2,14 @@ package bluepill.server.controller;
 
 import bluepill.server.annotation.CurrentUserId;
 import bluepill.server.dto.common.ApiResponse;
+import bluepill.server.dto.user.UserProfileUpdateRequest;
 import bluepill.server.dto.user.UserProfileResponse;
 import bluepill.server.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 @Tag(name="User")
@@ -26,9 +24,27 @@ public class UserController {
     @GetMapping("/{publicId}")
     public ApiResponse<UserProfileResponse> getUserProfile(@Parameter(description = "조회할 사용자의 publicId", example="550e8400-e29b-41d4-a716-446655440000")
                                                            @PathVariable UUID publicId,
-                                                           @Parameter(hidden = true) @CurrentUserId Long loginUserId){
-        UserProfileResponse response = userService.getProfile(publicId, loginUserId);
+                                                           @Parameter(hidden = true) @CurrentUserId Long userId){
+        UserProfileResponse response = userService.getProfile(publicId, userId);
 
         return ApiResponse.success("프로필 조회 성공", response);
+    }
+
+    @Operation(summary = "프로필 수정", description = """
+            로그인한 사용자의 프로필(닉네임, 프로필 이미지)을 수정합니다.
+            
+            **닉네임 처리 정책**
+            - 최초 로그인(닉네임 미설정) 상태에서 닉네임을 입력하지 않으면 랜덤 닉네임이 자동 부여됩니다.
+            - 기존 닉네임이 있는 상태에서 닉네임을 비워서 요청하면 400 오류가 반환됩니다.
+            - 이미 사용 중인 닉네임으로 수정 시 409 오류가 반환됩니다.
+            
+            **프로필 이미지 처리 정책**
+            - 이미지 URL을 입력하지 않으면 기존 이미지가 유지됩니다.
+            """)
+    @PatchMapping("/me")
+    public ApiResponse<UserProfileResponse> updateUserProfile(@Parameter(hidden = true) @CurrentUserId Long userId, @RequestBody UserProfileUpdateRequest request){
+        UserProfileResponse response = userService.updateProfile(userId, request);
+
+        return ApiResponse.success("프로필 수정 성공", response);
     }
 }

--- a/src/main/java/bluepill/server/domain/User.java
+++ b/src/main/java/bluepill/server/domain/User.java
@@ -36,7 +36,7 @@ public class User extends BaseTimeEntity {
     @Column(name = "provider", nullable = false, length = 20)
     private Provider provider;
 
-    @Column(name = "nickname", length = 15)
+    @Column(name = "nickname", unique = true, length = 15)
     private String nickname;
 
     @Column(name = "email", length = 255)
@@ -71,5 +71,10 @@ public class User extends BaseTimeEntity {
                 .provider(provider)
                 .email(email)
                 .build();
+    }
+
+    public void updateProfile(String nickname, String imageUrl) {
+        this.nickname = nickname;
+        if(imageUrl != null) this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/bluepill/server/dto/user/UserProfileResponse.java
+++ b/src/main/java/bluepill/server/dto/user/UserProfileResponse.java
@@ -12,7 +12,6 @@ public record UserProfileResponse(
         Long planId,
         Boolean isPublic,
         Long characterCnt,
-        Long postCnt,
         boolean isOwner
 
 ) {
@@ -24,7 +23,6 @@ public record UserProfileResponse(
                 user.getEmail(),
                 user.getPlan() != null? user.getPlan().getId(): null,
                 user.getIsPublic(),
-                0L,
                 0L,
                 isOwner
         );

--- a/src/main/java/bluepill/server/dto/user/UserProfileResponse.java
+++ b/src/main/java/bluepill/server/dto/user/UserProfileResponse.java
@@ -1,5 +1,7 @@
 package bluepill.server.dto.user;
 
+import bluepill.server.domain.User;
+
 import java.util.UUID;
 
 public record UserProfileResponse(
@@ -14,4 +16,17 @@ public record UserProfileResponse(
         boolean isOwner
 
 ) {
+    public static UserProfileResponse from(User user, boolean isOwner) {
+        return new UserProfileResponse(
+                user.getPublicId(),
+                user.getNickname(),
+                user.getImageUrl(),
+                user.getEmail(),
+                user.getPlan() != null? user.getPlan().getId(): null,
+                user.getIsPublic(),
+                0L,
+                0L,
+                isOwner
+        );
+    }
 }

--- a/src/main/java/bluepill/server/dto/user/UserProfileUpdateRequest.java
+++ b/src/main/java/bluepill/server/dto/user/UserProfileUpdateRequest.java
@@ -1,0 +1,7 @@
+package bluepill.server.dto.user;
+
+public record UserProfileUpdateRequest(
+    String nickname,
+    String imageUrl
+) {
+}

--- a/src/main/java/bluepill/server/repository/CharacterCardRepository.java
+++ b/src/main/java/bluepill/server/repository/CharacterCardRepository.java
@@ -1,6 +1,7 @@
 package bluepill.server.repository;
 
 import bluepill.server.domain.CharacterCard;
+import bluepill.server.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -20,4 +21,5 @@ public interface CharacterCardRepository extends JpaRepository<CharacterCard, Lo
            "LEFT JOIN FETCH c.creator " +
            "WHERE c.publicId = :publicId AND c.isDeleted = false")
     Optional<CharacterCard> findDetailByPublicId(@Param("publicId") UUID publicId);
+    long countByCreatorAndIsDeletedFalse(User user);
 }

--- a/src/main/java/bluepill/server/repository/UserRepository.java
+++ b/src/main/java/bluepill/server/repository/UserRepository.java
@@ -10,4 +10,6 @@ public interface  UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByPublicIdAndIsDeletedFalse(UUID publicId);
     Optional<User> findByProviderAndProviderId(User.Provider provider, String providerId);
+    Optional<User> findByUserId(Long userId);
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/bluepill/server/service/UserService.java
+++ b/src/main/java/bluepill/server/service/UserService.java
@@ -5,6 +5,7 @@ import bluepill.server.dto.user.UserProfileResponse;
 import bluepill.server.dto.user.UserProfileUpdateRequest;
 import bluepill.server.exception.BusinessException;
 import bluepill.server.exception.ErrorCode;
+import bluepill.server.repository.CharacterCardRepository;
 import bluepill.server.repository.UserRepository;
 import bluepill.server.util.NicknameGenerator;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,7 @@ import java.util.UUID;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final CharacterCardRepository characterCardRepository;
     private final NicknameGenerator nicknameGenerator;
 
     public User findById(Long id) {
@@ -37,9 +39,7 @@ public class UserService {
 
         boolean isOwner = userId != null && userId.equals(user.getUserId());
 
-        //todo: 캐릭터, 게시물 개수
-        long characterCnt = 0L;
-        long postCnt = 0L;
+        long characterCnt = characterCardRepository.countByCreatorAndIsDeletedFalse(user);
 
         return new UserProfileResponse(
                 user.getPublicId(),
@@ -49,7 +49,6 @@ public class UserService {
                 user.getPlan() != null ? user.getPlan().getId() : null,
                 user.getIsPublic(),
                 characterCnt,
-                postCnt,
                 isOwner
         );
     };

--- a/src/main/java/bluepill/server/service/UserService.java
+++ b/src/main/java/bluepill/server/service/UserService.java
@@ -2,9 +2,11 @@ package bluepill.server.service;
 
 import bluepill.server.domain.User;
 import bluepill.server.dto.user.UserProfileResponse;
+import bluepill.server.dto.user.UserProfileUpdateRequest;
 import bluepill.server.exception.BusinessException;
 import bluepill.server.exception.ErrorCode;
 import bluepill.server.repository.UserRepository;
+import bluepill.server.util.NicknameGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +19,7 @@ import java.util.UUID;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final NicknameGenerator nicknameGenerator;
 
     public User findById(Long id) {
         return userRepository.findById(id)
@@ -28,11 +31,11 @@ public class UserService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 
-    public UserProfileResponse getProfile(UUID publicId, Long loginUserId) {
+    public UserProfileResponse getProfile(UUID publicId, Long userId) {
         User user = userRepository.findByPublicIdAndIsDeletedFalse(publicId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        boolean isOwner = loginUserId != null && loginUserId.equals(user.getUserId());
+        boolean isOwner = userId != null && userId.equals(user.getUserId());
 
         //todo: 캐릭터, 게시물 개수
         long characterCnt = 0L;
@@ -50,4 +53,27 @@ public class UserService {
                 isOwner
         );
     };
+
+    @Transactional
+    public UserProfileResponse updateProfile(Long userId, UserProfileUpdateRequest request) {
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        String nickname;
+
+        //최초 로그인
+        if (request.nickname() == null | request.nickname().isBlank()) {
+            if(user.getNickname() == null|| user.getNickname().isBlank()) {
+                //랜덤 닉네임 부여
+                nickname = nicknameGenerator.generate();
+            }else {
+                //기존 닉네임 있지만 빈칸 -> 거부
+                throw new BusinessException(ErrorCode.NICKNAME_MISSING);
+            }
+        } else {
+            nickname = request.nickname();
+        }
+        user.updateProfile(nickname, request.imageUrl());
+        return UserProfileResponse.from(user,true);
+    }
 }

--- a/src/main/java/bluepill/server/util/NicknameGenerator.java
+++ b/src/main/java/bluepill/server/util/NicknameGenerator.java
@@ -1,0 +1,65 @@
+package bluepill.server.util;
+
+import bluepill.server.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class NicknameGenerator {
+
+    private final UserRepository userRepository;
+
+    private static final List<String> ADJECTIVES = List.of("뻘쭘한", "킹받는", "하찮은", "꼬질꼬질한", "뽀짝한", "멍청한", "쭈굴쭈굴한", "깜찍한",
+            "어리바리한", "얄미운", "능글맞은", "허접한", "오염된", "엉뚱한", "어설픈", "처량한",
+            "뒤죽박죽한", "쪼잔한", "옹졸한", "까다로운", "골때리는", "귀여운", "불쌍한", "징그러운",
+            "짭쪼름한", "유영하는", "텁텁한", "멍때리는", "우스꽝스러운", "엉성한", "시시콜콜한",
+            "구질구질한", "너덜너덜한", "후줄근한", "울퉁불퉁한", "삐딱한", "어수선한", "시끄러운",
+            "시큰둥한", "요란한", "폭신한", "꾸덕한", "바삭한", "눅눅한", "흐물흐물한", "뾰루퉁한",
+            "뚱한", "삐진", "따수운", "따듯한", "심술궂은", "투덜거리는", "틱틱대는", "새침한",
+            "달달한", "찰진", "신박한", "웃픈", "짠내나는", "춤추는", "노래하는", "낭만있는",
+            "나사빠진", "어리석은", "깐깐한", "의기소침한", "처참한", "싸늘한", "초췌한", "까칠한",
+            "뻔뻔한", "무해한", "순수한", "방랑하는", "자유로운", "몽환적인", "둠칫둠칫하는", "신난",
+            "세상편한", "베베꼬인", "당당한", "영악한", "느끼한", "리듬타는");
+
+    private static final List<String> NOUNS = List.of(
+            "라쿤", "수달", "고양이", "강아지", "시바견", "쿼카", "해파리", "반달가슴곰",
+            "마카롱", "밀크티", "아메리카노", "꿀단지", "밤하늘", "오로라", "푸딩", "타자기",
+            "펭귄", "햄스터", "고슴도치", "관종", "직장인", "학생", "사람", "애주가",
+            "모험가", "일기장", "사차원", "확성기", "불도저", "포크레인", "만년필", "나침반",
+            "병아리", "돋보기", "우주", "사막여우", "알파카", "돌고래", "웰시코기", "기니피그",
+            "카피바라", "타조", "앵무조개", "바다거북", "존재", "따오기", "지구", "키조개",
+            "낙타", "달팽이", "양배추", "아스파라거스", "파프리카", "감자", "고구마", "생강",
+            "고수", "왈라비", "대파", "완두콩", "마라탕", "공기밥", "안경", "탕후루",
+            "은둔고수", "개척자", "방랑자", "수호자", "파괴자", "추적자", "국밥", "수면양말",
+            "꼬마유령", "외계인", "텔레파시", "효자손", "슬리퍼", "뻥튀기", "뽁뽁이", "시간여행자",
+            "블랙홀", "우주인", "물만두", "도토리", "비눗방울", "그림자", "바코드", "종이비행기",
+            "시한폭탄", "스노우볼", "허수아비", "인공눈물", "치즈스틱", "만화책", "누룽지",
+            "삼각김밥", "메추리알", "연금술사", "유리구슬", "길치", "행인", "스파이", "츄러스",
+            "달고나", "바람개비", "야광별"
+    );
+
+    private static final Random RANDOM = new Random();
+
+    public String generate(){
+        for (int i = 0; i < 5; i++) {
+            String adjective = ADJECTIVES.get(RANDOM.nextInt(ADJECTIVES.size()));
+            String noun = NOUNS.get(RANDOM.nextInt(NOUNS.size()));
+            int number = RANDOM.nextInt(9000) + 1000;
+            String nickname = adjective + noun + number;
+
+            if(!userRepository.existsByNickname(nickname)){
+                return nickname;
+            }
+        }
+        //5회 모두 중복 시 fallback
+        return ADJECTIVES.get(RANDOM.nextInt(ADJECTIVES.size()))
+                + NOUNS.get(RANDOM.nextInt(NOUNS.size()))
+                + UUID.randomUUID().toString().substring(0, 5);
+
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#32 
> 예시
>
> - 기능 추가: fixes #이슈번호
> - 버그 수정: fixes #이슈번호
> - 프론트엔드/백엔드 레포가 분리된 경우: 기능 추가시, fixes enb-solution/레포지토리명#이슈번호
    >   버그 수정시, fixes enb-solution/레포지토리명#이슈번호
    >   ⚠️ 다른 레포 이슈는 자동 close 되지 않으며, 링크만 연결됩니다.

## 📝작업 내용
- 내 프로필 조회 시 생성한 캐릭터 수 함께 조회되도록 characterCardRepository 주입 후 count 메서드 통해 개수 조회
- 내 프로필 수정 시 getNickname ==null인 경우 최초 로그인, null 아닌 경우 기존 로그인으로 처리
- 기존 로그인 사용자인 경우 null값으로 닉네임 수정 시 "닉네임 필수 에러" 처리
- 최초 로그인 시 null 값으로 닉네임 저장 시 랜덤 닉네임 처리
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?