### PR TITLE
feat: Google과 Discord용 OAuth2 설정 추가

### DIFF
--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -6,6 +6,28 @@ spring:
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+          discord:
+            client-id: ${DISCORD_CLIENT_ID}
+            client-secret: ${DISCORD_CLIENT_SECRET}
+            client-name: Discord
+            authorization-grant-type: authorization_code
+            scope: identify,email
+            provider: discord
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+        provider:
+          discord:
+            authorization-uri: https://discord.com/api/oauth2/authorize
+            token-uri: https://discord.com/api/oauth2/token
+            user-info-uri: https://discord.com/api/users/@me
+            user-name-attribute: id
+
   jpa:
     hibernate:
       ddl-auto: validate


### PR DESCRIPTION
```
  security:
    oauth2:
      client:
        registration:
          google:
            client-id: ${GOOGLE_CLIENT_ID}
            client-secret: ${GOOGLE_CLIENT_SECRET}
          discord:
            client-id: ${DISCORD_CLIENT_ID}
            client-secret: ${DISCORD_CLIENT_SECRET}
            client-name: Discord
            authorization-grant-type: authorization_code
            scope: identify,email
            provider: discord
            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
        provider:
          discord:
            authorization-uri: https://discord.com/api/oauth2/authorize
            token-uri: https://discord.com/api/oauth2/token
            user-info-uri: https://discord.com/api/users/@me
            user-name-attribute: id
``` 이 부분 이렇게 하는게 맞을지 확인점요